### PR TITLE
fix: fix readme image src

### DIFF
--- a/packages/svg_icon_widget/README.md
+++ b/packages/svg_icon_widget/README.md
@@ -11,7 +11,7 @@ A Flutter package that provides a simple way to use SVG icons in your Flutter ap
 **Show some ❤️ and star the repo to support the project**
 
 <p>
-  <img src="https://github.com/xsahil03x/widget_wave/blob/main/packages/svg_icon_widget/assets/showcase.png" alt="A showcase of FlutterSvgIcon" height="700"/>
+  <img src="https://github.com/xsahil03x/widget_wave/blob/main/packages/svg_icon_widget/assets/showcase.png?raw=true" alt="A showcase of SvgIcon" height="700"/>
 </p>
 
 ## Features


### PR DESCRIPTION
This pull request includes a small change to the `packages/svg_icon_widget/README.md` file. The change updates the URL of an image to ensure it is displayed correctly by adding the `?raw=true` query parameter.

* [`packages/svg_icon_widget/README.md`](diffhunk://#diff-2f2f85282954fd0584bdfeebafcf5f4c25fdf6c25ae9adf2f73d638777a784d1L14-R14): Updated image URL to include `?raw=true` for proper display.